### PR TITLE
Remove legal subtitles/disclaimer and website entries; add liability disclaimer to Terms & Conditions

### DIFF
--- a/src/pages/LegalNoticePage.tsx
+++ b/src/pages/LegalNoticePage.tsx
@@ -7,13 +7,11 @@ import { Mail, Phone, MapPin, Building2, ShieldCheck } from 'lucide-react';
 const content = {
   en: {
     title: 'Legal Notice',
-    subtitle: 'Impressum — mandatory information pursuant to Art. XII.4 of the Belgian Code of Economic Law',
     sections: [
       {
         heading: 'Editor & Operator',
         items: [
           { label: 'Name', value: 'Gabriel Muresan' },
-          { label: 'Operating under', value: 'Romanian Business Hub' },
         ],
       },
       {
@@ -40,21 +38,17 @@ const content = {
         heading: 'Supervisory Authority',
         items: [
           { label: 'Authority', value: 'FPS Economy, SMEs, Self-Employed and Energy' },
-          { label: 'Website', value: 'economie.fgov.be', href: 'https://economie.fgov.be' },
         ],
       },
     ],
-    disclaimer: 'The information on this website is provided for general informational purposes only. Romanian Business Hub strives to keep the information up to date and accurate, but makes no warranties about the completeness, accuracy, or reliability of any information on this site.',
   },
   nl: {
     title: 'Wettelijke Vermeldingen',
-    subtitle: 'Impressum — verplichte informatie conform Art. XII.4 van het Belgisch Wetboek van Economisch Recht',
     sections: [
       {
         heading: 'Redacteur & Exploitant',
         items: [
           { label: 'Naam', value: 'Gabriel Muresan' },
-          { label: 'Handelend onder', value: 'Romanian Business Hub' },
         ],
       },
       {
@@ -81,21 +75,17 @@ const content = {
         heading: 'Toezichthoudende Autoriteit',
         items: [
           { label: 'Autoriteit', value: 'FOD Economie, KMO, Middenstand en Energie' },
-          { label: 'Website', value: 'economie.fgov.be', href: 'https://economie.fgov.be' },
         ],
       },
     ],
-    disclaimer: 'De informatie op deze website is uitsluitend bedoeld voor algemene informatiedoeleinden. Romanian Business Hub streeft ernaar de informatie actueel en correct te houden, maar geeft geen garanties over de volledigheid, nauwkeurigheid of betrouwbaarheid van de informatie op deze site.',
   },
   ro: {
     title: 'Mențiuni Legale',
-    subtitle: 'Impressum — informații obligatorii conform Art. XII.4 din Codul belgian al Dreptului Economic',
     sections: [
       {
         heading: 'Editor & Operator',
         items: [
           { label: 'Nume', value: 'Gabriel Muresan' },
-          { label: 'Activând sub denumirea', value: 'Romanian Business Hub' },
         ],
       },
       {
@@ -121,12 +111,10 @@ const content = {
       {
         heading: 'Autoritate de Supraveghere',
         items: [
-          { label: 'Autoritate', value: 'SPF Economie, PME, Indépendants et Énergie' },
-          { label: 'Website', value: 'economie.fgov.be', href: 'https://economie.fgov.be' },
+          { label: 'Autoritate', value: 'FPS Economy, SMEs, Self-Employed and Energy' },
         ],
       },
     ],
-    disclaimer: 'Informațiile de pe acest site sunt furnizate exclusiv în scopuri informative generale. Romanian Business Hub depune eforturi pentru a menține informațiile actualizate și corecte, dar nu oferă garanții privind caracterul complet, exactitatea sau fiabilitatea oricăror informații de pe acest site.',
   },
 };
 
@@ -141,7 +129,7 @@ const LegalNoticePage = () => {
     <>
       <SEO
         title={`${c.title} | Romanian Business Hub`}
-        description={c.subtitle}
+        description="Editor & Operator, registered office, enterprise and VAT details, contact information, and supervisory authority."
         noindex
       />
       <div className="min-h-screen flex flex-col bg-muted/30">
@@ -153,9 +141,6 @@ const LegalNoticePage = () => {
             <h1 className="font-playfair text-4xl font-bold text-foreground mb-3">
               {c.title}
             </h1>
-            <p className="text-sm text-muted-foreground leading-relaxed border-l-4 border-romania-blue pl-4">
-              {c.subtitle}
-            </p>
           </div>
 
           {/* Sections */}
@@ -198,11 +183,6 @@ const LegalNoticePage = () => {
                 </div>
               );
             })}
-          </div>
-
-          {/* Disclaimer */}
-          <div className="mt-8 bg-muted rounded-2xl p-6 text-sm text-muted-foreground leading-relaxed">
-            {c.disclaimer}
           </div>
 
         </main>

--- a/src/pages/TermsConditionsPage.tsx
+++ b/src/pages/TermsConditionsPage.tsx
@@ -58,6 +58,10 @@ const TermsConditionsPage = () => {
           content: "To the maximum extent permitted by law:\n\n• We are not liable for indirect, incidental, or consequential damages\n• Our total liability is limited to the amount you paid to use the Service (if any)\n• We are not liable for losses resulting from:\n  - Unauthorized access to your account\n  - Service interruptions or errors\n  - Third-party actions\n  - User-generated content\n  - Business transactions between users and businesses"
         },
         {
+          title: "11A. Liability Disclaimer",
+          content: "Romanian Business Hub provides a directory service 'as is.' While we aim to increase visibility for listed businesses, we do not guarantee a specific increase in turnover, client numbers, or financial results. We are an intermediary platform and are not responsible for the quality, legality, or safety of the services provided by the businesses listed in our directory."
+        },
+        {
           title: "12. Indemnification",
           content: "You agree to indemnify and hold harmless Romanian Business Hub, its owners, employees, and affiliates from:\n\n• Claims arising from your use of the Service\n• Violations of these Terms\n• Violations of third-party rights\n• Content you submit to the Service\n• Your business activities listed on the Service"
         },
@@ -137,6 +141,10 @@ const TermsConditionsPage = () => {
           content: "În măsura maximă permisă de lege:\n\n• Nu suntem răspunzători pentru daune indirecte, accidentale sau consecutive\n• Răspunderea noastră totală este limitată la suma pe care ați plătit-o pentru a utiliza Serviciul (dacă există)\n• Nu suntem răspunzători pentru pierderi rezultate din:\n  - Acces neautorizat la contul dvs.\n  - Întreruperi sau erori ale serviciului\n  - Acțiuni ale terților\n  - Conținut generat de utilizatori\n  - Tranzacții comerciale între utilizatori și afaceri"
         },
         {
+          title: "11A. Declarație privind Răspunderea",
+          content: "Romanian Business Hub oferă un serviciu de director 'ca atare'. Deși ne propunem să creștem vizibilitatea afacerilor listate, nu garantăm o creștere specifică a cifrei de afaceri, a numărului de clienți sau a rezultatelor financiare. Suntem o platformă intermediară și nu suntem responsabili pentru calitatea, legalitatea sau siguranța serviciilor furnizate de afacerile listate în directorul nostru."
+        },
+        {
           title: "12. Indemnizație",
           content: "Sunteți de acord să despăgubiți și să protejați Romanian Business Hub, proprietarii, angajații și afiliatii săi de:\n\n• Reclamații rezultate din utilizarea Serviciului\n• Încălcări ale acestor Termeni\n• Încălcări ale drepturilor terților\n• Conținut pe care îl trimiteți către Serviciu\n• Activitățile dvs. de afaceri listate pe Serviciu"
         },
@@ -214,6 +222,10 @@ const TermsConditionsPage = () => {
         {
           title: "11. Beperking van Aansprakelijkheid",
           content: "Voor zover maximaal toegestaan door de wet:\n\n• Wij zijn niet aansprakelijk voor indirecte, incidentele of gevolgschade\n• Onze totale aansprakelijkheid is beperkt tot het bedrag dat u hebt betaald voor het gebruik van de Service (indien van toepassing)\n• Wij zijn niet aansprakelijk voor verliezen die voortvloeien uit:\n  - Ongeautoriseerde toegang tot uw account\n  - Service-onderbrekingen of fouten\n  - Acties van derden\n  - Door gebruikers gegenereerde inhoud\n  - Zakelijke transacties tussen gebruikers en bedrijven"
+        },
+        {
+          title: "11A. Aansprakelijkheidsverklaring",
+          content: "Romanian Business Hub biedt een gidsdienst 'zoals die is'. Hoewel wij ernaar streven de zichtbaarheid van vermelde bedrijven te vergroten, garanderen wij geen specifieke stijging van omzet, aantal klanten of financiële resultaten. Wij zijn een intermediair platform en zijn niet verantwoordelijk voor de kwaliteit, wettelijkheid of veiligheid van de diensten die worden geleverd door de bedrijven in onze gids."
         },
         {
           title: "12. Vrijwaring",


### PR DESCRIPTION
### Motivation
- Remove redundant or potentially sensitive legal copy (subtitles, operating-under label, supervisory website links, and the page disclaimer) from the legal notice page and provide a concise SEO description.
- Clarify platform liability in the Terms & Conditions by adding an explicit disclaimer that the directory is an intermediary and does not guarantee business results.

### Description
- Deleted subtitle strings and the rendered subtitle paragraph from `LegalNoticePage.tsx` and replaced the SEO description with a concise static description.
- Removed the `Operating under` item and supervisory authority website items from the multilingual `content` in `LegalNoticePage.tsx`, and updated the Romanian supervisory authority label to the English `FPS Economy, SMEs, Self-Employed and Energy` value.
- Removed the `disclaimer` strings from the multilingual `content` and removed the disclaimer rendering block from the legal notice page.
- Added a new "11A. Liability Disclaimer" section to the `TermsConditionsPage.tsx` for English, Romanian, and Dutch to explicitly state the directory is provided "as is" and that no revenue/client guarantees are made.

### Testing
- Ran TypeScript type checking (`npm run type-check`) and the project build (`npm run build`) locally and both completed successfully.
- Ran linting (`npm run lint`) and no lint errors were reported for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2eed83588324bf07084264728c4f)