### PR TITLE
Add DSA notice-and-action copy to Contact and Terms pages

### DIFF
--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -178,6 +178,11 @@ const ContactPage = () => {
                             </div>
                           </div>
                         </div>
+
+                        <div className="mt-6 rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+                          <p className="font-semibold">{t('contact.reportContentTitle')}</p>
+                          <p className="mt-2">{t('contact.reportContentText')}</p>
+                        </div>
                       </div>
 
                       <div className="mt-6 pt-6 border-t border-gray-200 text-center">

--- a/src/pages/TermsConditionsPage.tsx
+++ b/src/pages/TermsConditionsPage.tsx
@@ -39,7 +39,7 @@ const TermsConditionsPage = () => {
         },
         {
           title: "7. Reviews and Comments",
-          content: "Users may submit reviews and comments. By doing so, you agree that:\n\n• Reviews must be based on personal experience\n• Reviews must be honest and not misleading\n• You will not post fake or fraudulent reviews\n• You will not be compensated for positive reviews\n• We reserve the right to remove inappropriate reviews\n• We are not responsible for user-generated content"
+          content: "Users may submit reviews and comments. By doing so, you agree that:\n\n• Reviews must be based on personal experience\n• Reviews must be honest and not misleading\n• You will not post fake or fraudulent reviews\n• You will not be compensated for positive reviews\n• We reserve the right to remove inappropriate reviews\n• We are not responsible for user-generated content\n\nReport Content: If you believe any content on this platform (listings or reviews) is illegal, fraudulent, or infringes on your rights, please notify us immediately at info@ro-businesshub.be. We will investigate and take appropriate action within 72 hours."
         },
         {
           title: "8. Prohibited Activities",
@@ -122,7 +122,7 @@ const TermsConditionsPage = () => {
         },
         {
           title: "7. Recenzii și Comentarii",
-          content: "Utilizatorii pot trimite recenzii și comentarii. Procedând astfel, sunteți de acord că:\n\n• Recenziile trebuie să fie bazate pe experiență personală\n• Recenziile trebuie să fie oneste și nu înșelătoare\n• Nu veți posta recenzii false sau frauduloase\n• Nu veți fi compensat pentru recenzii pozitive\n• Ne rezervăm dreptul de a elimina recenzii necorespunzătoare\n• Nu suntem responsabili pentru conținutul generat de utilizatori"
+          content: "Utilizatorii pot trimite recenzii și comentarii. Procedând astfel, sunteți de acord că:\n\n• Recenziile trebuie să fie bazate pe experiență personală\n• Recenziile trebuie să fie oneste și nu înșelătoare\n• Nu veți posta recenzii false sau frauduloase\n• Nu veți fi compensat pentru recenzii pozitive\n• Ne rezervăm dreptul de a elimina recenzii necorespunzătoare\n• Nu suntem responsabili pentru conținutul generat de utilizatori\n\nRaportare Conținut: Dacă considerați că orice conținut de pe această platformă (listări sau recenzii) este ilegal, fraudulos sau vă încalcă drepturile, vă rugăm să ne anunțați imediat la info@ro-businesshub.be. Vom investiga și vom lua măsurile corespunzătoare în termen de 72 de ore."
         },
         {
           title: "8. Activități Interzise",
@@ -205,7 +205,7 @@ const TermsConditionsPage = () => {
         },
         {
           title: "7. Beoordelingen en Opmerkingen",
-          content: "Gebruikers kunnen beoordelingen en opmerkingen indienen. Door dit te doen, gaat u ermee akkoord dat:\n\n• Beoordelingen moeten gebaseerd zijn op persoonlijke ervaring\n• Beoordelingen moeten eerlijk en niet misleidend zijn\n• U geen valse of frauduleuze beoordelingen zult plaatsen\n• U niet zult worden gecompenseerd voor positieve beoordelingen\n• Wij het recht behouden om ongepaste beoordelingen te verwijderen\n• Wij niet verantwoordelijk zijn voor door gebruikers gegenereerde inhoud"
+          content: "Gebruikers kunnen beoordelingen en opmerkingen indienen. Door dit te doen, gaat u ermee akkoord dat:\n\n• Beoordelingen moeten gebaseerd zijn op persoonlijke ervaring\n• Beoordelingen moeten eerlijk en niet misleidend zijn\n• U geen valse of frauduleuze beoordelingen zult plaatsen\n• U niet zult worden gecompenseerd voor positieve beoordelingen\n• Wij het recht behouden om ongepaste beoordelingen te verwijderen\n• Wij niet verantwoordelijk zijn voor door gebruikers gegenereerde inhoud\n\nContent Melden: Als u van mening bent dat enige inhoud op dit platform (vermeldingen of beoordelingen) illegaal of frauduleus is, of inbreuk maakt op uw rechten, laat het ons dan onmiddellijk weten via info@ro-businesshub.be. Wij zullen dit onderzoeken en binnen 72 uur passende actie ondernemen."
         },
         {
           title: "8. Verboden Activiteiten",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -191,7 +191,9 @@
     "errorTitle": "Error",
     "validationError": "Validation Error",
     "validationErrorMessage": "Please check the form for errors and try again.",
-    "submissionError": "Submission Error"
+    "submissionError": "Submission Error",
+    "reportContentTitle": "Report Content",
+    "reportContentText": "If you believe any content on this platform (listings or reviews) is illegal, fraudulent, or infringes on your rights, please notify us immediately at info@ro-businesshub.be. We will investigate and take appropriate action within 72 hours."
   },
   "faq": {
     "title": "Frequently Asked Questions",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -191,7 +191,9 @@
     "errorTitle": "Fout",
     "validationError": "Validatiefout",
     "validationErrorMessage": "Controleer het formulier op fouten en probeer het opnieuw.",
-    "submissionError": "Verzendfout"
+    "submissionError": "Verzendfout",
+    "reportContentTitle": "Content Melden",
+    "reportContentText": "Als u van mening bent dat enige inhoud op dit platform (vermeldingen of beoordelingen) illegaal of frauduleus is, of inbreuk maakt op uw rechten, laat het ons dan onmiddellijk weten via info@ro-businesshub.be. Wij zullen dit onderzoeken en binnen 72 uur passende actie ondernemen."
   },
   "faq": {
     "title": "Veelgestelde Vragen",

--- a/src/translations/ro.json
+++ b/src/translations/ro.json
@@ -191,7 +191,9 @@
     "errorTitle": "Eroare",
     "validationError": "Eroare de Validare",
     "validationErrorMessage": "Te rugăm să verifici formularul pentru erori și să încerci din nou.",
-    "submissionError": "Eroare la Trimitere"
+    "submissionError": "Eroare la Trimitere",
+    "reportContentTitle": "Raportează Conținut",
+    "reportContentText": "Dacă considerați că orice conținut de pe această platformă (listări sau recenzii) este ilegal, fraudulos sau vă încalcă drepturile, vă rugăm să ne anunțați imediat la info@ro-businesshub.be. Vom investiga și vom lua măsurile corespunzătoare în termen de 72 de ore."
   },
   "faq": {
     "title": "Întrebări Frecvente",


### PR DESCRIPTION
### Motivation
- Provide a clear DSA-style notice-and-action clause so users can report illegal, fraudulent, or rights-infringing listings or reviews and the platform can commit to a timely response.
- Surface the reporting guidance in both the site UI (`/contact`) and the legal copy (`/terms-conditions`) in all supported languages to reduce legal risk and improve user trust.

### Description
- Added a localized `Report Content` notice block to the Contact page UI in `src/pages/ContactPage.tsx` that displays `t('contact.reportContentTitle')` and `t('contact.reportContentText')` to users. 
- Added translation keys `reportContentTitle` and `reportContentText` to `src/translations/en.json`, `src/translations/ro.json`, and `src/translations/nl.json` with the DSA-style reporting sentence and 72-hour response commitment. 
- Appended the same notice-and-action clause to the "Reviews and Comments" section in `src/pages/TermsConditionsPage.tsx` for English, Romanian, and Dutch content.

### Testing
- Ran `npm run lint`, which failed in this environment due to missing project dependencies (ESLint error: cannot find package `@eslint/js`), so automated lint validation did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd34fe50ec8324a18fb7d6fdb4bf49)